### PR TITLE
improve the Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,19 @@
 language: php
 
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
 php:
   - 7.2
   - 7.1
 
 before_script:
+    - phpenv config-rm xdebug.ini
     - composer self-update
-    - composer --prefer-source --dev install
-    - cp phpunit.xml.dist phpunit.xml
+    
+install:
+    - composer install --prefer-dist
 
 script: 
-    - vendor/bin/phpunit -c phpunit.xml
+    - vendor/bin/phpunit


### PR DESCRIPTION
* copying the PHPUnit config is not necessary, PHPUnit will use the dist file by default anyway
* caching Composer files will speed up successive builds
* the `--dev` option is set by default on `composer install`
* disable the Xdebug extension to speed up the test execution
* use `--prefer-dist` instead of `--prefer-source` to speed up package installation