### PR TITLE
Fixed the scale of bcmod for PHP versions 7.2+

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -226,7 +226,7 @@ class Validator
     private function local_bcmod($operand, $modulus)
     {
         if (function_exists('bcmod')) {
-            return PHP_VERSION_ID >= 70200
+            return PHP_VERSION_ID >= 70300
                 ? bcmod($operand, $modulus, 0)
                 : bcmod($operand, $modulus);
         }

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -226,7 +226,9 @@ class Validator
     private function local_bcmod($operand, $modulus)
     {
         if (function_exists('bcmod')) {
-            return bcmod($operand, $modulus, 0);
+            bcscale(0);
+
+            return bcmod($operand, $modulus);
         }
 
         $take = 5;

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -226,7 +226,7 @@ class Validator
     private function local_bcmod($operand, $modulus)
     {
         if (function_exists('bcmod')) {
-            return version_compare (PHP_VERSION, '7.2') > 0
+            return version_compare(PHP_VERSION, '7.2') > 0
                 ? bcmod($operand, $modulus, 0)
                 : bcmod($operand, $modulus);
         }

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -226,9 +226,11 @@ class Validator
     private function local_bcmod($operand, $modulus)
     {
         if (function_exists('bcmod')) {
-            bcscale(0);
+            $oldScale = bcscale(0);
+            $mod = bcmod($operand, $modulus);
+            bcscale($oldScale);
 
-            return bcmod($operand, $modulus);
+            return $mod;
         }
 
         $take = 5;

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -226,7 +226,7 @@ class Validator
     private function local_bcmod($operand, $modulus)
     {
         if (function_exists('bcmod')) {
-            return bcmod($operand, $modulus);
+            return bcmod($operand, $modulus, 0);
         }
 
         $take = 5;

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -226,7 +226,7 @@ class Validator
     private function local_bcmod($operand, $modulus)
     {
         if (function_exists('bcmod')) {
-            return version_compare(PHP_VERSION, '7.2') > 0
+            return PHP_VERSION_ID >= 70200
                 ? bcmod($operand, $modulus, 0)
                 : bcmod($operand, $modulus);
         }

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -226,11 +226,9 @@ class Validator
     private function local_bcmod($operand, $modulus)
     {
         if (function_exists('bcmod')) {
-            $oldScale = bcscale(0);
-            $mod = bcmod($operand, $modulus);
-            bcscale($oldScale);
-
-            return $mod;
+            return version_compare (PHP_VERSION, '7.2') > 0
+                ? bcmod($operand, $modulus, 0)
+                : bcmod($operand, $modulus);
         }
 
         $take = 5;

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -226,7 +226,7 @@ class Validator
     private function local_bcmod($operand, $modulus)
     {
         if (function_exists('bcmod')) {
-            return PHP_VERSION_ID >= 70300
+            return PHP_VERSION_ID >= 70200
                 ? bcmod($operand, $modulus, 0)
                 : bcmod($operand, $modulus);
         }


### PR DESCRIPTION
Fixes the issue, that a previous bcscale screws with the precision of the bcmod function.