### PR TITLE
Add Cameroon to IBAN Registry

### DIFF
--- a/src/Swift/iban_registry.yaml
+++ b/src/Swift/iban_registry.yaml
@@ -190,6 +190,22 @@ CH:
     branch_identifier_position: ''
     branch_identifier_structure: ''
     branch_identifier_regex: ''
+CM:
+    country_name: Cameroon
+    iban_structure: CM2!n23!n
+    bban_structure: 23!n
+    iban_regex: '/^CM\d{2}\d{23}$/'
+    bban_regex: '/^\d{23}$/'
+    iban_length: 27
+    bban_length: 23
+    iban_electronic_format_example: CM2110002000300277976315008
+    iban_print_format_example: 'CM21 1000 2000 3002 7797 6315 008'
+    bank_identifier_position:
+    bank_identifier_structure:
+    bank_identifier_regex: ''
+    branch_identifier_position: ''
+    branch_identifier_structure: ''
+    branch_identifier_regex: ''
 CR:
     country_name: 'Costa Rica'
     iban_structure: CR2!n4!n14!n

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -46,6 +46,7 @@ final class ValidatorTest extends TestCase
         yield ['BR1800360305000010009795493C1'];
         yield ['BY13NBRB3600900000002Z00AB00'];
         yield ['CH9300762011623852957'];
+        yield ['CM2110002000300277976315008'];
         yield ['CR05015202001026284066'];
         yield ['CY17002001280000001200527600'];
         yield ['CZ6508000000192000145399'];


### PR DESCRIPTION
Add Cameroon to the IBAN Registry. Information taken from:
https://bank.codes/iban/structure/cameroon/
https://www.iban.com/structure