### PR TITLE
[2.x] Add support for php 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,17 @@ cache:
 php:
   - 7.4
   - 7.3
+  - 8.0snapshot
 
 before_script:
     - phpenv config-rm xdebug.ini
     - composer self-update
     
 install:
+    - if [ "$TRAVIS_PHP_VERSION" = "8.0snapshot" ]; then composer remove --dev friendsofphp/php-cs-fixer --no-update --no-interaction; fi;
     - composer install --prefer-dist
 
 script:
-    - vendor/bin/php-cs-fixer fix --dry-run
+    - if [ "$TRAVIS_PHP_VERSION" != "8.0snapshot" ]; then vendor/bin/php-cs-fixer fix --dry-run; fi;
     - vendor/bin/phpstan analyze
     - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ cache:
     - $HOME/.composer/cache/files
 
 php:
+  - 8.0snapshot
   - 7.4
   - 7.3
-  - 8.0snapshot
 
 before_script:
     - phpenv config-rm xdebug.ini

--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,14 @@
 		}
 	},
 	"require" : {
-		"php" : "^7.3",
+		"php" : "^7.3|^8.0",
 		"symfony/options-resolver": "^3.4|^4.1|^5.0",
 		"symfony/yaml": "^3.4|^4.1|^5.0"
 	},
 	"require-dev" : {
-		"phpunit/phpunit" : "^9.1",
+		"phpunit/phpunit" : "^9.3",
 		"friendsofphp/php-cs-fixer": "^2.16.3",
-		"phpstan/phpstan": "^0.12.25"
+		"phpstan/phpstan": "^0.12.57"
 	},
 	"suggest": {
        		"ext-bcmath" : "This library makes use of bcmod function, so an installed bcmath extension is recommended."

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
 		}
 	},
 	"require" : {
-		"php" : "^7.3|^8.0",
-		"symfony/options-resolver": "^3.4|^4.1|^5.0",
-		"symfony/yaml": "^3.4|^4.1|^5.0"
+		"php" : ">=7.3",
+		"symfony/options-resolver": "^3.4.43|^4.4.11|^5.0.11",
+		"symfony/yaml": "^3.4.44|^4.4.12|^5.1.4"
 	},
 	"require-dev" : {
 		"phpunit/phpunit" : "^9.3",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          beStrictAboutCoversAnnotation="true"
          beStrictAboutOutputDuringTests="true"
@@ -10,15 +9,14 @@
          failOnRisky="true"
          colors="true"
          verbose="true">
-    <testsuites>
-        <testsuite name="Iban Validation Library Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Iban Validation Library Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -168,7 +168,7 @@ final class Validator
         return $bigInt;
     }
 
-    private static function bigIntModulo97(string $bigInt): ?string
+    private static function bigIntModulo97(string $bigInt): string
     {
         $modulus = '97';
 


### PR DESCRIPTION
This PR add's support for php8.

* `php-cs-fixer` had to be removed during build process, since it doesn't support php 8, yet
* I upgraded the `phpunit.xml.dist` config to phpunit `9.3` standard
* the `Validator::bigIntModulo97` method had to drop it's nullable state, since phpstan correctly stated:
```
Method Iban\Validation\Validator::bigIntModulo97() never returns null so it can be removed from the return typehint.
```