### PR TITLE
Sunset support for PHP 8.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
+        php-version: [ '8.1', '8.2', '8.3', '8.4', '8.5' ]
         prefer-lowest: ['', '--prefer-lowest --prefer-stable']
         coverage-driver: [ 'xdebug' ]
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A small library for validating International Bankaccount Numbers (IBANs) based o
 See https://www.swift.com/standards/data-standards/iban for more information.
 
 [![.github/workflows/ci.yaml](https://github.com/jschaedl/iban-validation/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/jschaedl/iban-validation/actions/workflows/ci.yaml)
-[![PHP Version](https://img.shields.io/badge/version-PHP%208.0%2B-lightblue.svg)](https://img.shields.io/badge/version-PHP%207.4%2B-lightgrey.svg)
+[![PHP Version](https://img.shields.io/badge/version-PHP%208.1%2B-lightblue.svg)](https://img.shields.io/badge/version-PHP%208.1%2B-lightblue.svg)
 [![Latest Stable Version](https://poser.pugx.org/jschaedl/iban-validation/v/stable)](https://packagist.org/packages/jschaedl/iban-validation) 
 [![Latest Unstable Version](https://poser.pugx.org/jschaedl/iban-validation/v/unstable)](https://packagist.org/packages/jschaedl/iban-validation) 
 [![Total Downloads](https://poser.pugx.org/jschaedl/iban-validation/downloads)](https://packagist.org/packages/jschaedl/iban-validation) 

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "2.x-dev"
+			"dev-master": "3.x-dev"
 		}
 	},
 	"require" : {
-		"php" : "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+		"php" : "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
 		"ext-ctype": "*",
 		"symfony/options-resolver": "^5.4|^6|^7"
 	},


### PR DESCRIPTION
- Remove PHP 8.0 from composer.json version constraints
- Remove PHP 8.0 from CI workflow test matrix
- Update README.md PHP version badge to reflect 8.1+ requirement
- Update branch alias to 3.x-dev for major version

Resolves #111

🤖 Generated with [Claude Code](https://claude.ai/code)