### PR TITLE
Allow Symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 	"require" : {
 		"php" : "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
 		"ext-ctype": "*",
-		"symfony/options-resolver": "^5.4|^6|^7"
+		"symfony/options-resolver": "^5.4|^6|^7|^8"
 	},
 	"suggest": {
        		"ext-bcmath" : "This library makes use of bcmod function, so an installed bcmath extension is recommended."


### PR DESCRIPTION
As Symfony 8 has been released last week I think it would be a great idea to allow this package to be used in new and existing Symfony 8 projects. Or are looking to upgrade and run into the issue it's not 8 compatible.

This PR fixes that issue